### PR TITLE
Create repository.yaml

### DIFF
--- a/repository.yaml
+++ b/repository.yaml
@@ -1,0 +1,3 @@
+name: "Steve Add-On Repository"
+url: "https://github.com/scruysberghs/addon-steve"
+maintainer: "Steven Cruysberghs <steven@smartenergycontrol.be>"


### PR DESCRIPTION
try to get the repo to be recognized as an add-on in HA UI

# Proposed Changes

I could not get the repo to be recognised as a valid add-on repo in Homeassistant UI without this file. Make sure to edit repo url and maintaner name and email before merging...

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
